### PR TITLE
Fix: handle _action_masks buffer in single-task scenarios

### DIFF
--- a/tdmpc2/common/layers.py
+++ b/tdmpc2/common/layers.py
@@ -212,7 +212,8 @@ def api_model_conversion(target_state_dict, source_state_dict):
 	# copy log_std_min and log_std_max from target_state_dict to new_state_dict
 	new_state_dict['log_std_min'] = target_state_dict['log_std_min']
 	new_state_dict['log_std_dif'] = target_state_dict['log_std_dif']
-	new_state_dict['_action_masks'] = target_state_dict['_action_masks']
+	if '_action_masks' in target_state_dict:
+		new_state_dict['_action_masks'] = target_state_dict['_action_masks']
 
 	# copy new_state_dict to source_state_dict
 	source_state_dict.update(new_state_dict)


### PR DESCRIPTION
The current checkpoint conversion function code in `tdmpc2/tdmpc2/common/layers.py` assumes the `_action_masks` buffer exists for all scenarios, but this buffer is only used in multi-task mode. This fix makes the buffer optional during checkpoint loading, allowing single-task checkpoints to load correctly.

- Fix KeyError when loading checkpoints in single-task mode
- Make `_action_masks` buffer optional in api_model_conversion
- Only copy `_action_masks` when present in state dict

---

Tested command:
```bash
python evaluate.py task=dog-run model_size=5 checkpoint=/checkpoints/dmcontrol/dog-run-1.pt save_video=true
```

Terminal output before the fix:
```
Traceback (most recent call last):
  File "/tdmpc2/tdmpc2/evaluate.py", line 59, in evaluate
    agent.load(cfg.checkpoint)
  File "/tdmpc2/tdmpc2/tdmpc2.py", line 94, in load
    state_dict = api_model_conversion(self.model.state_dict(), state_dict)
  File "/tdmpc2/tdmpc2/common/layers.py", line 215, in api_model_conversion
    new_state_dict['_action_masks'] = target_state_dict['_action_masks']
KeyError: '_action_masks'
```

No errors after the fix.
